### PR TITLE
Add epics backlog from review recommendations

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -1,0 +1,33 @@
+# Proposed Epics
+
+## 1) Repository Hygiene and Baseline Guardrails
+- Remove committed run artifacts (e.g., `jules_session_*`) and prevent recurrence via `.gitignore`.
+- Align project tree so only authoritative source files remain; document expected workspace layout.
+- Outcome: clean working tree, reduced reviewer confusion, fewer accidental imports of stale code.
+
+## 2) Documentation and Runtime Alignment
+- Update README to match actual persistence (Parquet, not pickle) and the Python version required by `Pipfile`.
+- Add a short “supported runtimes” section that clarifies local/dev expectations vs. production deployment.
+- Outcome: contributors install the correct toolchain and understand the real storage layer.
+
+## 3) Dependency and Packaging Safety
+- Remove the unintended `datetime` PyPI dependency and refresh the lockfile; audit for other shadowing risks.
+- Clarify pandas/pyarrow compatibility guidance and keep the `PYARROW_IGNORE_TIMEZONE` fix prominent.
+- Outcome: fewer dependency conflicts and clearer import behavior across environments.
+
+## 4) Data Ingestion Robustness and Performance
+- Define a fixed schema for empty SHAB days; skip or normalize empty-day Parquet writes safely.
+- Reuse a shared requests session across date ranges, strengthen retry policy (status-forcelist, respect `Retry-After`).
+- Replace per-iteration concatenation with list accumulation to avoid quadratic cost on multi-year ranges.
+- Outcome: resilient ingestion with predictable schema and materially faster range processing.
+
+## 5) Flask Execution Model Hardening
+- Decouple data refresh from request handling (scheduled/CLI job) and make Flask serve only persisted artifacts.
+- Add file-level locking around Parquet and plot writes; ensure multi-worker deployments do not race or duplicate work.
+- Outcome: deterministic refreshes, safe concurrent access, and clearer separation of web vs. batch concerns.
+
+## 6) UI and API Reliability
+- Switch static asset references to `url_for` and tune progress reporting to reflect real phases of work.
+- Guard BFS PxWeb enrichment with error handling; allow SHAB plots to render even when BFS is unavailable.
+- Normalize canton parsing (explode multi-canton entries) and consider time-aware axes for plots.
+- Outcome: correct asset resolution, honest progress UX, and stable endpoints even under upstream failures.

--- a/epics/01_repository_hygiene.md
+++ b/epics/01_repository_hygiene.md
@@ -1,0 +1,5 @@
+# Repository Hygiene and Baseline Guardrails
+
+- Remove committed run artifacts (e.g., `jules_session_*`) and prevent recurrence via `.gitignore`.
+- Align project tree so only authoritative source files remain; document expected workspace layout.
+- Outcome: clean working tree, reduced reviewer confusion, fewer accidental imports of stale code.

--- a/epics/02_documentation_and_runtime_alignment.md
+++ b/epics/02_documentation_and_runtime_alignment.md
@@ -1,0 +1,5 @@
+# Documentation and Runtime Alignment
+
+- Update README to match actual persistence (Parquet, not pickle) and the Python version required by `Pipfile`.
+- Add a short “supported runtimes” section that clarifies local/dev expectations vs. production deployment.
+- Outcome: contributors install the correct toolchain and understand the real storage layer.

--- a/epics/03_dependency_and_packaging_safety.md
+++ b/epics/03_dependency_and_packaging_safety.md
@@ -1,0 +1,5 @@
+# Dependency and Packaging Safety
+
+- Remove the unintended `datetime` PyPI dependency and refresh the lockfile; audit for other shadowing risks.
+- Clarify pandas/pyarrow compatibility guidance and keep the `PYARROW_IGNORE_TIMEZONE` fix prominent.
+- Outcome: fewer dependency conflicts and clearer import behavior across environments.

--- a/epics/04_data_ingestion_robustness_and_performance.md
+++ b/epics/04_data_ingestion_robustness_and_performance.md
@@ -1,0 +1,6 @@
+# Data Ingestion Robustness and Performance
+
+- Define a fixed schema for empty SHAB days; skip or normalize empty-day Parquet writes safely.
+- Reuse a shared requests session across date ranges, strengthen retry policy (status-forcelist, respect `Retry-After`).
+- Replace per-iteration concatenation with list accumulation to avoid quadratic cost on multi-year ranges.
+- Outcome: resilient ingestion with predictable schema and materially faster range processing.

--- a/epics/05_flask_execution_model_hardening.md
+++ b/epics/05_flask_execution_model_hardening.md
@@ -1,0 +1,5 @@
+# Flask Execution Model Hardening
+
+- Decouple data refresh from request handling (scheduled/CLI job) and make Flask serve only persisted artifacts.
+- Add file-level locking around Parquet and plot writes; ensure multi-worker deployments do not race or duplicate work.
+- Outcome: deterministic refreshes, safe concurrent access, and clearer separation of web vs. batch concerns.

--- a/epics/06_ui_and_api_reliability.md
+++ b/epics/06_ui_and_api_reliability.md
@@ -1,0 +1,6 @@
+# UI and API Reliability
+
+- Switch static asset references to `url_for` and tune progress reporting to reflect real phases of work.
+- Guard BFS PxWeb enrichment with error handling; allow SHAB plots to render even when BFS is unavailable.
+- Normalize canton parsing (explode multi-canton entries) and consider time-aware axes for plots.
+- Outcome: correct asset resolution, honest progress UX, and stable endpoints even under upstream failures.


### PR DESCRIPTION
## Summary
- document prioritized epics derived from the recent static review
- capture hygiene, documentation/runtime alignment, dependency safety, ingestion hardening, and UX/API reliability tracks
- add individual markdown files per epic to make the backlog consumable per-track

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69456d5c230c8329be9dd0ab55003254)